### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "python3"
+  run = ""
+  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # AWS EKS & MSK demo infrastructure
 
+[![Run on Repl.it](https://repl.it/badge/github/iferca/eks_kafka)](https://repl.it/github/iferca/eks_kafka)
+
 The `cdk.json` file tells the CDK Toolkit how to execute your app.
 
 This project is set up like a standard Python project.  The initialization


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).